### PR TITLE
fix: remove module from ModuleLoader cache map on promise reject

### DIFF
--- a/src/util/module-loader.ts
+++ b/src/util/module-loader.ts
@@ -32,7 +32,10 @@ export class ModuleLoader {
     let promise = this._promiseMap.get(modulePath);
     if (!promise) {
       promise = this._ngModuleLoader.load(splitString[0], splitString[1]);
-      this._promiseMap.set(modulePath, promise);
+      promise.catch(() => {
+          this._promiseMap.delete(modulePath);
+      });
+      this._promiseMap.set(modulePath, promise);         
     }
 
     return promise.then(loadedModule => {


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
